### PR TITLE
Temp workaround for Playwright config file merge issue

### DIFF
--- a/samples/get-started/playwright.service.config.ts
+++ b/samples/get-started/playwright.service.config.ts
@@ -54,5 +54,7 @@ export default defineConfig(config, {
       // Allow service to access the localhost.
       exposeNetwork: '<loopback>'
     }
-  }
+  },
+  // Tenmp workaround for config merge bug in OSS https://github.com/microsoft/playwright/pull/28224
+  projects: config.projects? config.projects : [{}]
 });


### PR DESCRIPTION
There is a minor bug in playwright runner which sets projects to null when merging configs with no projects hence declaring projects to null in case of no projects in default config.