### PR TITLE
Add service option in default config

### DIFF
--- a/samples/get-started/playwright.config.ts
+++ b/samples/get-started/playwright.config.ts
@@ -1,4 +1,14 @@
 import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// Name the test run if it's not named yet.
+process.env.PLAYWRIGHT_SERVICE_RUN_ID = process.env.PLAYWRIGHT_SERVICE_RUN_ID || new Date().toISOString();
+
+// Can be 'linux' or 'windows'.
+const os = process.env.PLAYWRIGHT_SERVICE_OS || 'linux';
+
 
 export default defineConfig({
   testDir: './tests',
@@ -9,6 +19,19 @@ export default defineConfig({
   reporter: 'html',
   use: {
     trace: 'on-first-retry',
+    connectOptions: {
+      wsEndpoint: `${process.env.PLAYWRIGHT_SERVICE_URL}?cap=${JSON.stringify({
+        // Can be 'linux' or 'windows'.
+        os,
+        runId: process.env.PLAYWRIGHT_SERVICE_RUN_ID
+      })}`,
+      timeout: 30000,
+      headers: {
+        'x-mpt-access-key': process.env.PLAYWRIGHT_SERVICE_ACCESS_TOKEN!
+      },
+      // Allow service to access the localhost.
+      exposeNetwork: '<loopback>'
+    }
   },
   projects: [
     {


### PR DESCRIPTION
Sample PR to edit existing config to integrate service option. after doing this, npx playwright test should be able to run test against service without the need of playwright.service.config.ts file