### PR TITLE
chore: Node.js getting started nits

### DIFF
--- a/samples/get-started/azure-pipelines.yml
+++ b/samples/get-started/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
 - task: NodeTool@0
   inputs:
     versionSource: 'spec'
-    versionSpec: '>16.x'
+    versionSpec: '>18.x'
 
 
 - task: PowerShell@2

--- a/samples/get-started/package-lock.json
+++ b/samples/get-started/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@azure/microsoft-playwright-testing": "^1.0.0-beta.3",
         "@playwright/test": "^1.47",
+        "@types/node": "^18.19.68",
         "dotenv": "^16.4.5"
       }
     },
@@ -325,6 +326,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.68.tgz",
+      "integrity": "sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/agent-base": {
@@ -736,6 +747,13 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/samples/get-started/package.json
+++ b/samples/get-started/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@azure/microsoft-playwright-testing": "^1.0.0-beta.3",
     "@playwright/test": "^1.47",
+    "@types/node": "^18.19.68",
     "dotenv": "^16.4.5"
   }
 }

--- a/samples/get-started/playwright.service.config.ts
+++ b/samples/get-started/playwright.service.config.ts
@@ -6,10 +6,10 @@ import config from './playwright.config';
 export default defineConfig(
   config,
   getServiceConfig(config, {
-	exposeNetwork: '<loopback>',
-    	timeout: 30000,
-   	os: ServiceOS.LINUX,
-    	useCloudHostedBrowsers: true
+    exposeNetwork: '<loopback>',
+    timeout: 30000,
+    os: ServiceOS.LINUX,
+    useCloudHostedBrowsers: true
   }),
   {
     /* 


### PR DESCRIPTION
We need `@types/node` in order to have types for `process.` - thats what `create-playwright` generates by default.

nit: some formatting